### PR TITLE
(doc) Fix markdown formatting

### DIFF
--- a/win/chocolatey/jarmemu.nuspec
+++ b/win/chocolatey/jarmemu.nuspec
@@ -17,17 +17,18 @@
     <tags>jarmemu simulator arm armv7 java educational</tags>
     <summary>Simple ARMv7 simulator written in Java, intended for educational purpose</summary>
     <description><![CDATA[# JArmEmu
-                          ### Simple ARMv7 simulator written in Java, intended for educational purpose.
+### Simple ARMv7 simulator written in Java, intended for educational purpose.
 
-                          ## Features
-                          JArmEmu is a simple, user-friendly simulator that provides basic control and information about a simulated ARMv7 architecture.
+## Features
+JArmEmu is a simple, user-friendly simulator that provides basic control and information about a simulated ARMv7 architecture.
 
-                          JArmEmu is powered by an ARMv7 interpreter built *Ex Nihilo* for this project, which provides real-time syntax highlighting,
-                          intelligent auto-completion, memory, stack and register monitoring...
+JArmEmu is powered by an ARMv7 interpreter built *Ex Nihilo* for this project, which provides real-time syntax highlighting,
+intelligent auto-completion, memory, stack and register monitoring...
 
-                          You can write your program using the ARMv7 instruction set (refer to
-                          [Instructions.md](https://github.com/Dwight-Studio/JArmEmu/blob/main/Instructions.md)) and include GNU Assembly directives (only the basic ones are implemented, you can refer to syntax
-                          highlighting or auto-completion to see if it is available).]]></description>
+You can write your program using the ARMv7 instruction set (refer to
+[Instructions.md](https://github.com/Dwight-Studio/JArmEmu/blob/main/Instructions.md)) and include GNU Assembly directives (only the basic ones are implemented, you can refer to syntax
+highlighting or auto-completion to see if it is available).]]>
+    </description>
     <releaseNotes>https://github.com/Dwight-Studio/JArmEmu/releases/tag/v1.0.0</releaseNotes>
     <dependencies>
         <dependency id='openjdk' version="21.0.0"/>


### PR DESCRIPTION
This will make the markdown render correctly on the Chocolatey Community Repository:

<img width="1026" alt="image" src="https://github.com/user-attachments/assets/c90cf814-0a16-469d-a825-12a5306652b3">
